### PR TITLE
Fix for Redmine2 compatibility on CentOS 6

### DIFF
--- a/lib/sys_controller_patch.rb
+++ b/lib/sys_controller_patch.rb
@@ -20,7 +20,7 @@ module SysControllerPatch
                 return fetch_changesets_without_by_root_url
             end
 
-            repositories = Repository.where(root_url: params[:root_url].to_s)
+            repositories = Repository.where(:root_url => params[:root_url].to_s)
 
             unless repositories
                 render :nothing => true, :status => 404


### PR DESCRIPTION
With this change I was able to install the plugin on Redmine 2.6.3 running on CentOS 6. I am using this old version because the current versions of Redmine require a newer version of Ruby than is provided by the standard CentOS/RHEL 6 packages. The plugin appears to be working based on my testing so far.

```
Environment:
  Redmine version                2.6.3.stable
  Ruby version                   1.8.7-p374 (2013-06-27) [x86_64-linux]
  Rails version                  3.2.21
  Environment                    production
  Database adapter               MySQL
```