### PR TITLE
Remove use of alias_method_chain for Rails 5.1 compatiblitiy

### DIFF
--- a/lib/sys_controller_patch.rb
+++ b/lib/sys_controller_patch.rb
@@ -6,7 +6,8 @@ module SysControllerPatch
         base.extend(ClassMethods)
         base.send(:include, InstanceMethods)
         base.class_eval do
-            alias_method_chain :fetch_changesets, :by_root_url
+            alias_method :fetch_changesets_without_by_root_url, :fetch_changesets
+            alias_method :fetch_changesets, :fetch_changesets_with_by_root_url
         end
     end
 


### PR DESCRIPTION
Address #4 by removing the use of alias_method_chain