### PR TITLE
support rails >= 5.1

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -5,9 +5,9 @@ Redmine::Plugin.register :redmine_scm_hookhelpers do
   author 'Lukas Pirl'
   author_url 'http://lukas-pirl.de/'
   description 'This Plugin provides helpers for commit hooks when using the Redmine SCM plugin.'
-  version '0.0.1'
+  version '0.1.0'
   url 'https://github.com/lpirl/redmine_scm_hookhelpers'
-  requires_redmine :version_or_higher => '2.5.0'
+  requires_redmine :version_or_higher => '3.4.2'
 end
 
 Rails.configuration.to_prepare do

--- a/init.rb
+++ b/init.rb
@@ -5,7 +5,7 @@ Redmine::Plugin.register :redmine_scm_hookhelpers do
   author 'Lukas Pirl'
   author_url 'http://lukas-pirl.de/'
   description 'This Plugin provides helpers for commit hooks when using the Redmine SCM plugin.'
-  version '0.1.0'
+  version '0.2.0'
   url 'https://github.com/lpirl/redmine_scm_hookhelpers'
   requires_redmine :version_or_higher => '3.4.2'
 end

--- a/lib/sys_controller_patch.rb
+++ b/lib/sys_controller_patch.rb
@@ -24,7 +24,7 @@ module SysControllerPatch
             repositories = Repository.where(root_url: params[:root_url].to_s)
 
             unless repositories
-                render :nothing => true, :status => 404
+                head :not_found
             end
 
             for repository in repositories
@@ -32,7 +32,7 @@ module SysControllerPatch
                 Rails.logger.info "fetched changesets for " + repository.root_url
             end
 
-            render :nothing => true, :status => 200
+            head :ok
         end
 
     end


### PR DESCRIPTION
'render :nothing => true' is [removed in rails 5.1](https://stackoverflow.com/q/34688726/921859) .  This PR is for rails > 5.1 which is redmine >= 3.4.2.  Actually, redmine_scm_hookhelpers v0.2.0 works with redmone 4.1.7 as well.